### PR TITLE
 Prevent syntax tree NPE for 0-arity function

### DIFF
--- a/src/main/java/org/scijava/parse/SyntaxTree.java
+++ b/src/main/java/org/scijava/parse/SyntaxTree.java
@@ -57,9 +57,11 @@ public class SyntaxTree implements Iterable<SyntaxTree> {
 		if (Tokens.isOperator(token)) {
 			final Operator op = (Operator) token;
 			final int arity = op.getArity();
-			if (arity > 0) children = new SyntaxTree[arity];
-			for (int i = children.length - 1; i >= 0; i--) {
-				children[i] = new SyntaxTree(tokens);
+			if (arity > 0) {
+				children = new SyntaxTree[arity];
+				for (int i = children.length - 1; i >= 0; i--) {
+					children[i] = new SyntaxTree(tokens);
+				}
 			}
 		}
 	}

--- a/src/test/java/org/scijava/parse/SyntaxTreeTest.java
+++ b/src/test/java/org/scijava/parse/SyntaxTreeTest.java
@@ -108,6 +108,25 @@ public class SyntaxTreeTest extends AbstractTest {
 		assertSameLists(expected, tree.postfix());
 	}
 
+	@Test
+	public void testNullaryFunction() {
+		// infix: f()
+		// postfix: f (0) <Fn>
+		final LinkedList<Object> queue = queue(var("f"), group(Operators.PARENS, 0), func());
+
+		// NB: SyntaxTree constructor consumes the queue, so save a copy.
+		final LinkedList<Object> expected = new LinkedList<Object>(queue);
+
+		final SyntaxTree tree = new SyntaxTree(queue);
+
+		assertNotNull(tree);
+		assertFunction(token(tree));
+		assertVariable("f", token(tree, 0));
+		assertGroup(Operators.PARENS, 0, token(tree, 1));
+
+		assertSameLists(expected, tree.postfix());
+	}
+
 	// -- Helper methods --
 
 	private LinkedList<Object> queue(final Object... args) {


### PR DESCRIPTION
Creating a `SyntaxTree` object with tokens that contain a 0-arity function throws a `NullReferenceException`. To reproduce:

```java
new ExpressionParser().parseTree("f()");
```

This pull request fixes that problem and adds a new test case to `SyntaxTreeTest`.