### PR TITLE
Use deepHashCode for children in SyntaxTree

### DIFF
--- a/src/main/java/org/scijava/parse/SyntaxTree.java
+++ b/src/main/java/org/scijava/parse/SyntaxTree.java
@@ -101,7 +101,7 @@ public class SyntaxTree implements Iterable<SyntaxTree> {
 
 	@Override
 	public int hashCode() {
-		return token.hashCode() ^ children.hashCode();
+		return token.hashCode() ^ Arrays.deepHashCode(children);
 	}
 
 	// -- Iterable methods --


### PR DESCRIPTION
This PR fixes [an error reported by lgtm.com](https://lgtm.com/projects/g/scijava/parsington/snapshot/f4773adf279ffea4d2cacf7947be4fb55c2f71c9/files/src/main/java/org/scijava/parse/SyntaxTree.java?sort=name&dir=ASC&mode=heatmap#x27f284fb8fa1341a:1).


>     return token.hashCode() ^ children.hashCode();
> The hashCode method on arrays only considers object identity and ignores array contents.
