### PR TITLE
Fix relative link for breakpoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Expression parsers are as old as the hills; what makes this one different?
   symbols, precedence and associativity you desire.
 * __Clean, well-commented codebase with unit tests.__ Import the source into
   your favorite IDE and watch Parsington in action by putting a breakpoint
-  [here](/scijava/parsington/blob/parsington-2.0.0/src/main/java/org/scijava/parsington/ExpressionParser.java#L152-L154).
+  [here](/src/main/java/org/scijava/parsington/ExpressionParser.java#L152-L154).
 
 ## History
 


### PR DESCRIPTION
The relative link currently in place resolves to a URL with duplicate repo/blob identifier: `[...]scijava/parsington/blob/master/scijava/parsington/blob/parsington-2.0.0/[...]`.

Let's put a real relative link, i.e. relative to the README in the current tree. Alternatively, we can put an absolute link to the tag, what do you think?
