### PR TITLE
Block Integer parsing of a string if it contains a decimal point.

### DIFF
--- a/src/main/java/org/scijava/parsington/Literals.java
+++ b/src/main/java/org/scijava/parsington/Literals.java
@@ -407,9 +407,8 @@ public final class Literals {
 		final boolean forceLong = "l".equalsIgnoreCase(force);
 		final boolean forceFloat = "f".equalsIgnoreCase(force);
 		final boolean forceDouble = "d".equalsIgnoreCase(force);
-		final int dot = number.indexOf(".");
 		Number result = null;
-		if ((dot == -1) && !forceFloat && !forceDouble) {
+		if ((m.start(3) == -1) && !forceFloat && !forceDouble) {
 			result = parseInteger(number, forceLong, 10);
 		}
 		if (result == null && !forceLong) {

--- a/src/main/java/org/scijava/parsington/Literals.java
+++ b/src/main/java/org/scijava/parsington/Literals.java
@@ -408,7 +408,8 @@ public final class Literals {
 		final boolean forceFloat = "f".equalsIgnoreCase(force);
 		final boolean forceDouble = "d".equalsIgnoreCase(force);
 		Number result = null;
-		if ((m.start(3) == -1) && !forceFloat && !forceDouble) {
+		if (m.group(3) == null && m.group(4) == null && !forceFloat && !forceDouble) {
+			// No decimal point and no exponent part. So this *might* be an integer!
 			result = parseInteger(number, forceLong, 10);
 		}
 		if (result == null && !forceLong) {

--- a/src/main/java/org/scijava/parsington/Literals.java
+++ b/src/main/java/org/scijava/parsington/Literals.java
@@ -407,8 +407,9 @@ public final class Literals {
 		final boolean forceLong = "l".equalsIgnoreCase(force);
 		final boolean forceFloat = "f".equalsIgnoreCase(force);
 		final boolean forceDouble = "d".equalsIgnoreCase(force);
+		final int dot = number.indexOf(".");
 		Number result = null;
-		if (!forceFloat && !forceDouble) {
+		if ((dot == -1) && !forceFloat && !forceDouble) {
 			result = parseInteger(number, forceLong, 10);
 		}
 		if (result == null && !forceLong) {


### PR DESCRIPTION
Small change improved the performance of the code for my usage.

Does the current code handle decimal numbers with a comma? 

eg 10,001 for 10.001

This change will do nothing for those cases. 

Quick test below showing the impact of generating the exception.

```
    public static void main(String[] args) {
        double[] doubles = {1.4, 1.8, 100.56, 3438535,43534545.67575 ,};
        int[] ints = {14, 18, 10056, 34385,43534545 ,};
        final long startTime = System.nanoTime();
        String[] parseThis = new String[doubles.length*2];
        int count =0;
        int good = 0;
        for (int x = 0; x < doubles.length; x++) {
           parseThis[x] = String.valueOf(doubles[x]);
           parseThis[x+ doubles.length] = String.valueOf(ints[x]);
        }
        for (int i = 0; i < 700000 ; i++) {
            try {
                String p = parseThis[i % 10];
                int dot = p.indexOf('.');
                if (dot == -1) {
                    Integer.parseInt(p);
                    good++;
                }
            } catch (NumberFormatException e) {
                // eat it
                count++;
            }
        }
        final long elapsed = System.nanoTime() - startTime;
        System.out.println("stop. good="+good+" exceptions=" + count+ " time="  + elapsed/1000000000.0);
    }
```
stop. good=350000 exceptions=0 time=0.022590425

change one line
```
    int dot = p.indexOf('X');
```
stop. good=350000 exceptions=350000 time=0.436176896