### PR TITLE
Alter parseString to accumulate StringBuilder appends vs individual calls

### DIFF
--- a/src/main/java/org/scijava/parsington/Literals.java
+++ b/src/main/java/org/scijava/parsington/Literals.java
@@ -231,6 +231,7 @@ public final class Literals {
 
 		boolean escaped = false;
 		final StringBuilder sb = new StringBuilder();
+		int startIndex = index;
 		while (true) {
 			if (index >= s.length()) pos.die("Unclosed string literal");
 			final char c = s.charAt(index);
@@ -249,6 +250,7 @@ public final class Literals {
 					}
 					sb.append((char) Integer.parseInt(octal, 8));
 					index += octal.length();
+					startIndex = index;
 					continue;
 				}
 				switch (c) {
@@ -284,10 +286,20 @@ public final class Literals {
 					default: // invalid escape
 						pos.die("Invalid escape sequence");
 				}
+				startIndex = index+1;
 			}
-			else if (c == '\\' && quote == '"') escaped = true;
-			else if (c == quote) break;
-			else sb.append(c);
+			else if (c == '\\' && quote == '"') {
+				escaped = true;
+				if (index - startIndex > 0) {
+					sb.append(s, startIndex, index); // before the escape
+				}
+				startIndex = -1;
+			} else if (c == quote) {
+				if (startIndex != -1 && index - startIndex > 0) {
+					sb.append(s, startIndex, index); // last segment
+				}
+				break;
+			}
 			index++;
 		}
 		pos.set(index + 1);


### PR DESCRIPTION
Code change to batch StringBuilder appends vs one per character.

Benchmark of STRING("'hello world'") shows a 36% improvement .

It passes the existing tests and my test batch. It needs another set of eyes on it before it is trusted.

<img width="1196" height="68" alt="Screenshot 2026-07-28 at 9 13 57 AM" src="https://github.com/user-attachments/assets/e3d97839-7896-4d7c-8c3c-b3ec144c0fc5" />
